### PR TITLE
Set ecobeeChangeMode category to My Apps

### DIFF
--- a/smartapps/ecobeeChangeMode
+++ b/smartapps/ecobeeChangeMode
@@ -21,7 +21,7 @@ definition(
     namespace: "yracine",
     author: "Yves Racine",
     description: "Change the mode manually (by pressing the app's play button) and automatically at the ecobee thermostat(s)",
-    category: "",
+    category: "My Apps",
     iconUrl: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience.png",
     iconX2Url: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience@2x.png")
 


### PR DESCRIPTION
The category was left blank, so without modification, a user won't see ecobeeChangeMode under "My Apps" once it has been published.
