### PR TITLE
Added null checking on thermostatList events type line 767

### DIFF
--- a/ecobee.devicetype.groovy
+++ b/ecobee.devicetype.groovy
@@ -764,7 +764,7 @@ void poll() {
         presence: (progDisplayName.toUpperCase()!='AWAY')? 'present':'not present'
 	]
      
-	if (data.thermostatList[0].events[indiceEvent].type == 'quickSave') {
+	if (data.thermostatList[0].events[indiceEvent] != null && 'quickSave' == data.thermostatList[0].events[indiceEvent].type ) {
 			dataEvents.programEndTimeMsg ="Quicksave running"
 	}
 


### PR DESCRIPTION
I installed your awesome ecobee device type but had trouble getting it to poll data due to a null pointer exception encountered on event type checking (line 767).  I added some simple null checking to help bypass this issue.  

Thanks for a great device type, this is awesome!